### PR TITLE
modified setup.py to searc openhmd.h in /usr/local/include (for brew use...

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,13 +3,13 @@
 from distutils.core import setup
 from distutils.extension import Extension
 from Cython.Distutils import build_ext
- 
-module1 = Extension("rift", 
+
+module1 = Extension("rift",
     ["pyrift.pyx", "Rift.cpp"],
     language="c++",
     libraries=["openhmd"],
-    include_dirs=['/usr/include/openhmd'])
- 
+    include_dirs=['/usr/include/openhmd','/usr/local/include/openhmd'])
+
 setup(name = 'rift',
     version = '1.0',
     description = 'Python OpenHMD Wrapper',


### PR DESCRIPTION
Lubosz, 

Thanks for your work on python-rift.
I slightly modified the setup.py to include /usr/local/include in the search path for brew users on mac.
I would be most thankful if you cared to update the official python-rift branch.

We're currently working at integrating your work in the blenderVR software, if you want to take a look:
http://dalaifelinto.com/blendervr/
https://github.com/BlenderVR

David Poirier-Quinot
