### PR TITLE
@ OpenHMD.cpp : comment out OHMD_BUTTON_COUNT

### DIFF
--- a/OpenHMD.cpp
+++ b/OpenHMD.cpp
@@ -64,9 +64,11 @@ void OpenHMD::printDeviceInfo() {
 	print("right eye aspect:", 1, OHMD_RIGHT_EYE_ASPECT_RATIO);
 	print("distortion k:",     6, OHMD_DISTORTION_K);
 
-	int bcount[1];
-	ohmd_device_geti(hmd, OHMD_BUTTON_COUNT, bcount);
-	printf("digital button count: %i\n", bcount[0]);
+	// bue 20180422: OHMD_BUTTON_COUNT causes troubles by
+	// compiling with latest openhmd version 0.2.0-3
+	//int bcount[1];
+	//ohmd_device_geti(hmd, OHMD_BUTTON_COUNT, bcount);
+	//printf("digital button count: %i\n", bcount[0]);
  
 	printf("\n");
 }


### PR DESCRIPTION
hi @lubosz and @TheOnlyJoey, 

Last June 20th, 2017 TheOnlyJoey (form OpenHMD) submitted a bunch of changes. 
Unfortunately cause the introduced OHMD_BUTTON_COUNT lines the build process to crash.
I use the latest openhmd library version 0.2.0-3 that I was able to install with debian 10 buster.
My friend tested on mac osx installing openhmd with brew and was running into  the same error. 
I was not yet able to test installation on a window, but I am quit sure the same error will happen.

This is the error I get:

/***
OpenHMD.cpp: In member function ‘void OpenHMD::printDeviceInfo()’:
OpenHMD.cpp:68:24: error: ‘OHMD_BUTTON_COUNT’ was not declared in this scope
  ohmd_device_geti(hmd, OHMD_BUTTON_COUNT, bcount);
                        ^~~~~~~~~~~~~~~~~
OpenHMD.cpp:68:24: note: suggested alternative: ‘OHMD_ROTATION_QUAT’
  ohmd_device_geti(hmd, OHMD_BUTTON_COUNT, bcount);
                        ^~~~~~~~~~~~~~~~~
                        OHMD_ROTATION_QUAT
error: command 'x86_64-linux-gnu-gcc' failed with exit status 1
***/

When this three lines are commented out, python-rift (or python-openhmd) can be build and installed, 
though I do not completely understand if the commenting out of this three lines causes any other harm.
Maybe TheOnlyJoey has a better fix then just commenting it out.
Anyhow please help to fix this problem. 

I really much appreciate the pioneer work you guys did to get VR into the blender game engine.
Thanks a bunch, Bue 
